### PR TITLE
Enable the app to recognize and deal with duplicate items.

### DIFF
--- a/src/main/java/yilia/.github/workflows/gradle.yml
+++ b/src/main/java/yilia/.github/workflows/gradle.yml
@@ -1,0 +1,50 @@
+name: Java CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        platform: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+      - name: Set up repository
+        uses: actions/checkout@master
+
+      - name: Set up repository
+        uses: actions/checkout@master
+        with:
+          ref: master
+
+      - name: Merge to master
+        run: git checkout --progress --force ${{ github.sha }}
+
+      - name: Validate Gradle Wrapper
+        uses: gradle/wrapper-validation-action@v1
+
+      - name: Setup JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: '11'
+          java-package: jdk+fx
+
+      - name: Build and check with Gradle
+        run: ./gradlew check
+
+      - name: Perform IO redirection test (*NIX)
+        if: runner.os == 'Linux'
+        working-directory:  ${{ github.workspace }}/text-ui-test
+        run: ./runtest.sh
+
+      - name: Perform IO redirection test (MacOS)
+        if: always() && runner.os == 'macOS'
+        working-directory:  ${{ github.workspace }}/text-ui-test
+        run: ./runtest.sh
+
+      - name: Perform IO redirection test (Windows)
+        if: always() && runner.os == 'Windows'
+        working-directory:  ${{ github.workspace }}/text-ui-test
+        shell: cmd
+        run: runtest.bat

--- a/src/main/java/yilia/Type.java
+++ b/src/main/java/yilia/Type.java
@@ -1,0 +1,10 @@
+package yilia;
+
+/**
+ * Represents four different types of a task.
+ */
+public enum Type {
+    TODO,
+    DEADLINE,
+    EVENT
+}

--- a/src/main/java/yilia/Ui.java
+++ b/src/main/java/yilia/Ui.java
@@ -136,10 +136,22 @@ public class Ui {
     }
     /**
      * Farewells to users.
+     *
      * @return A good bye message.
      */
     public String showBye() {
         String message = "Bye. Hope to see you again soon!";
+        System.out.println(message);
+        return message;
+    }
+    /**
+     * Shows duplicate task.
+     *
+     * @param task The task that already exists in the task list.
+     * @return A message to inform users of the duplicate task.
+     */
+    public String showDuplicate(Task task) {
+        String message = "The task " + task + " already exists in the task list.";
         System.out.println(message);
         return message;
     }

--- a/src/main/java/yilia/command/AddCommand.java
+++ b/src/main/java/yilia/command/AddCommand.java
@@ -41,6 +41,9 @@ public class AddCommand extends Command {
                 throw new DescriptionEmptyException(type);
             }
             Todo todo = new Todo(text);
+            if (tasks.anyMatch(todo)) {
+                return ui.showDuplicate(todo);
+            }
             tasks.add(todo);
             return ui.showAddStatus(tasks);
         }
@@ -51,9 +54,15 @@ public class AddCommand extends Command {
         try {
             if (type.equals(Type.DEADLINE)) {
                 Deadline deadline = new Deadline(info[0].strip(), info[1].strip().substring(3));
+                if (tasks.anyMatch(deadline)) {
+                    return ui.showDuplicate(deadline);
+                }
                 tasks.add(deadline);
             } else if (type.equals(Type.EVENT)) {
                 Event event = new Event(info[0].strip(), info[1].strip().substring(3));
+                if (tasks.anyMatch(event)) {
+                    return ui.showDuplicate(event);
+                }
                 tasks.add(event);
             }
         } catch (Exception e) {

--- a/src/main/java/yilia/task/Deadline.java
+++ b/src/main/java/yilia/task/Deadline.java
@@ -22,12 +22,35 @@ public class Deadline extends Task {
         super(content, isDone);
         this.date = LocalDate.parse(date);
     }
+    /**
+     * Returns the String representation.
+     *
+     * @return The String representation.
+     */
     @Override
     public String toString() {
         return "[D]" + super.toString() + " (by: " + date.format(DateTimeFormatter.ofPattern("MMM d yyyy")) + ")";
     }
+    /**
+     * Returns how the deadline should appear on a file.
+     *
+     * @return The text information.
+     */
     @Override
     public String parse() {
         return "D / " + (status() ? "1" : "0") + " / " + super.parse() + " / " + date;
+    }
+    /**
+     * Checks if two deadlines are the same.
+     *
+     * @param obj The other object to compare with.
+     * @return A boolean value indicating if two tasks are the same.
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof Deadline)) {
+            return false;
+        }
+        return super.equals(obj) && this.date.equals(((Deadline) obj).date);
     }
 }

--- a/src/main/java/yilia/task/Event.java
+++ b/src/main/java/yilia/task/Event.java
@@ -22,12 +22,35 @@ public class Event extends Task {
         super(content, isDone);
         this.date = LocalDate.parse(date);
     }
+    /**
+     * Returns the String representation.
+     *
+     * @return The String representation.
+     */
     @Override
     public String toString() {
         return "[E]" + super.toString() + " (at: " + date.format(DateTimeFormatter.ofPattern("MMM d yyyy")) + ")";
     }
+    /**
+     * Returns how the event should appear on a file.
+     *
+     * @return The text information.
+     */
     @Override
     public String parse() {
         return "E / " + (status() ? "1" : "0") + " / " + super.parse() + " / " + date;
+    }
+    /**
+     * Checks if two events are the same.
+     *
+     * @param obj The other object to compare with.
+     * @return A boolean value indicating if two tasks are the same.
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof Event)) {
+            return false;
+        }
+        return super.equals(obj) && this.date.equals(((Event) obj).date);
     }
 }

--- a/src/main/java/yilia/task/Task.java
+++ b/src/main/java/yilia/task/Task.java
@@ -64,13 +64,13 @@ public abstract class Task {
         if (!(obj instanceof Task)) {
             return false;
         }
-        return this.content == ((Task) obj).content;
+        return this.content.equals(((Task) obj).content);
     }
     /**
-     * Returns how the task should appear on a file.
+     * Returns whether the content is included in the task.
      *
      * @param content A substring that we want to know whether is contained.
-     * @return The text information.
+     * @return A boolean value indicating if the content appears on the task.
      */
     public boolean contains(String content) {
         return this.content.contains(content);

--- a/src/main/java/yilia/task/TaskList.java
+++ b/src/main/java/yilia/task/TaskList.java
@@ -55,4 +55,7 @@ public class TaskList {
              .forEach(task -> newList.add(task));
         return newList;
     }
+    public boolean anyMatch(Task newTask) {
+        return tasks.stream().anyMatch(task -> task.equals(newTask));
+    }
 }

--- a/src/main/java/yilia/task/Todo.java
+++ b/src/main/java/yilia/task/Todo.java
@@ -1,0 +1,44 @@
+package yilia.task;
+
+/**
+ * Represents a task that does not have a specific time or deadline.
+ */
+public class Todo extends Task {
+    public Todo(String content) {
+        super(content);
+    }
+    public Todo(String content, boolean isDone) {
+        super(content, isDone);
+    }
+    /**
+     * Returns the String representation.
+     *
+     * @return The String representation.
+     */
+    @Override
+    public String toString() {
+        return "[T]" + super.toString();
+    }
+    /**
+     * Returns how the todo should appear on a file.
+     *
+     * @return The text information.
+     */
+    @Override
+    public String parse() {
+        return "T / " + (status() ? "1" : "0") + " / " + super.parse();
+    }
+    /**
+     * Checks if two todos are the same.
+     *
+     * @param obj The other object to compare with.
+     * @return A boolean value indicating if two tasks are the same.
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof Todo)) {
+            return false;
+        }
+        return super.equals(obj);
+    }
+}


### PR DESCRIPTION
Sometimes users may forget they have added the same tasks in the task list before and they attempt to add them again.

Enabling duplicates checking and handling makes it better for users to deal with their tasks.